### PR TITLE
Add XDR (Special Drawing Rights) currency support

### DIFF
--- a/Sources/Money/Currencies/ISO4217Currency.swift
+++ b/Sources/Money/Currencies/ISO4217Currency.swift
@@ -495,6 +495,9 @@ extension Currency where Self == ISO4217Currency {
     /// Caribbean Guilder (XCG) or (532)
     @inlinable public static var XCG: ISO4217Currency { .init(alphabeticCode: "XCG", numericCode: "532", minorUnits: 2, name: "Caribbean Guilder") }
 
+    /// Special Drawing Rights (XDR) or (960)
+    @inlinable public static var XDR: ISO4217Currency { .init(alphabeticCode: "XDR", numericCode: "960", minorUnits: 0, name: "Special Drawing Rights") }
+
     /// CFA Franc BCEAO (XOF) or (952)
     @inlinable public static var XOF: ISO4217Currency { .init(alphabeticCode: "XOF", numericCode: "952", minorUnits: 0, name: "CFA Franc BCEAO") }
 
@@ -667,6 +670,7 @@ extension Currency where Self == ISO4217Currency {
             .XAF,
             .XCD,
             .XCG,
+            .XDR,
             .XOF,
             .XPF,
             .YER,

--- a/Tests/Money/ISO4217CurrencyRegistrationTests.swift
+++ b/Tests/Money/ISO4217CurrencyRegistrationTests.swift
@@ -134,6 +134,20 @@ struct ISO4217CurrencyRegistrationTests {
     // MARK: - Predefined Currencies Tests
 
     @Test
+    func currency_XDR_canBeInitializedByAlphabeticAndNumericCode() {
+        let byAlpha = ISO4217Currency(alphabeticCode: "XDR")
+        let byNumeric = ISO4217Currency(numericCode: "960")
+
+        #expect(byAlpha != nil)
+        #expect(byNumeric != nil)
+        #expect(byAlpha == byNumeric)
+        #expect(byAlpha?.alphabeticCode == "XDR")
+        #expect(byAlpha?.numericCode == "960")
+        #expect(byAlpha?.name == "Special Drawing Rights")
+        #expect(byAlpha?.minorUnits == 0)
+    }
+
+    @Test
     func currency_whenInitializedWithPredefinedCurrencyRegistry_createsCurrency() {
         let registry = ISO4217CurrencyRegistry()
         for currency in ISO4217Currency.registry.currencies {


### PR DESCRIPTION
## Summary
- Add ISO 4217 currency code XDR (960) for Special Drawing Rights
- XDR is the IMF's international reserve asset
- Uses 0 minor units following the pattern for non-circulating currencies where ISO 4217 lists N.A.

## Changes
- `Sources/Money/Currencies/ISO4217Currency.swift`: Add XDR static property and to predefined list
- `Tests/Money/ISO4217CurrencyRegistrationTests.swift`: Add tests for XDR lookup by alphabetic and numeric codes

## Test plan
- [x] All 68 existing tests pass
- [x] New XDR tests verify lookup by alphabetic code (XDR) and numeric code (960)

🤖 Generated with [Claude Code](https://claude.com/claude-code)